### PR TITLE
feat(project): add new game 'Balango'

### DIFF
--- a/aws/iam/github_iam_roles.tf
+++ b/aws/iam/github_iam_roles.tf
@@ -24,6 +24,13 @@ locals {
         policies      = [data.terraform_remote_state.web.outputs.site_deploy_policy_arns["soloscripted"]]
       }
     }
+    "balango" = {
+      "production" = {
+        description   = "IAM role for deploying the balango site to the production environment."
+        ref_condition = "repo:SoloScripted/balango:environment:production"
+        policies      = [data.terraform_remote_state.web.outputs.site_deploy_policy_arns["balango"]]
+      }
+    }
     "sudokode" = {
       "production" = {
         description   = "IAM role for deploying the sudokode site to the production environment."

--- a/aws/web/sites.tf
+++ b/aws/web/sites.tf
@@ -8,5 +8,9 @@ locals {
       domains     = ["sudokode.soloscripted.com"]
       origin_path = "/sudokode"
     }
+    "balango" = {
+      domains     = ["balango.soloscripted.com"]
+      origin_path = "/balango"
+    }
   }
 }

--- a/github/repositories.tf
+++ b/github/repositories.tf
@@ -22,6 +22,22 @@ locals {
       }
     }
 
+    balango = {
+      description        = "A hyper-casual one-finger game about balancing a stick. Keep the stick upright as long as possible as the difficulty increases."
+      visibility         = "public"
+      protect_production = true
+      topics             = ["flutter", "dart", "game", "mobile-game", "hyper-casual", "one-finger-game", "balance-game"]
+      required_checks    = ["build"]
+      secrets = {
+        AWS_ADMIN_ROLE_ARN = data.terraform_remote_state.iam.outputs.github_actions_role_arns["balango-production"]
+      }
+      variables = {
+        AWS_REGION                     = "eu-north-1"
+        AWS_S3_SITE_BUCKET_NAME        = data.terraform_remote_state.web.outputs.web_assets_bucket_id
+        AWS_CLOUDFRONT_DISTRIBUTION_ID = data.terraform_remote_state.web.outputs.cloudfront_distribution_ids["balango"]
+      }
+    }
+
     flutter-shared-components = {
       description     = "Shared Flutter components and utilities for SoloScripted projects."
       visibility      = "public"


### PR DESCRIPTION
This commit introduces the necessary infrastructure for the new hyper-casual game, "Balango".

It includes the following additions:
- A new public GitHub repository `SoloScripted/balango` with appropriate topics, branch protection, and CI/CD variables.
- An AWS IAM role (`GitHubActionsRole-balango-production`) to allow GitHub Actions to deploy the game to the production environment.
- AWS CloudFront and DNS configurations to serve the game's website at `balango.soloscripted.com`.